### PR TITLE
Install only production dependencies from NPM

### DIFF
--- a/node/entrypoint.sh
+++ b/node/entrypoint.sh
@@ -11,7 +11,7 @@ mkdir -p ${BUILD_DIR}
 cp -R ${WORKSPACE}/${CODE}/. ${BUILD_DIR}
 cd ${BUILD_DIR}
 if [ -e "package.json" ]; then
-    npm install
+    npm install --production
 else
     echo "No requirements found. Skipping install"
 fi


### PR DESCRIPTION
Equivalent to installing dependencies from `requirements.txt` rather than `requirements-test.txt` when packaging a Python lambda.