### PR TITLE
Entrypoint updates for node packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ You can change the default behavior of this packager by using the environment va
 
 | Variable Name | Default | Required | Description |
 |-------------- | ------- | ---------| ----------- |
+| `ARTIFACT_CODE_PREFIX` | Empty | no | name of the directory inside your zip file containing the code |
 | `ARTIFACT_NAME` | `deployment.zip` | no | name of your artifact or zip file that you want to output |
 | `CONTAINER_BUILD_DIRECTORY` | `/build` | no | build output directory __inside__ your container |
 | `CI_WORKSPACE` | Docker working dir | no | workspace directory __inside__ your container |
@@ -83,3 +84,58 @@ You can change the default behavior of this packager by using the environment va
 
 See the _Examples_ for Python, except where you see `3mcloud/lambda-packager:python-3.6` replace that 
 with `3mcloud/lambda-packager:node-12.16`
+
+The default behavior of the node packager is to assume that the `package.json` and `package-lock.json` 
+are in the same directory as the entry point for your application. For example, your application looks like this:
+
+```bash
+.
+├── app.js
+├── package.json
+```
+
+Then just use the defaults as shown in the _Examples_.
+
+Some projects, however, have a nested structure. If you have a folder structure that looks like this, which was created by `sam init`:
+
+```bash
+.
+├── README.md
+├── __tests__
+│   └── unit
+│       └── handlers
+│           ├── get-all-items.test.js
+│           ├── get-by-id.test.js
+│           └── put-item.test.js
+├── buildspec.yml
+├── env.json
+├── events
+│   ├── event-get-all-items.json
+│   ├── event-get-by-id.json
+│   └── event-post-item.json
+├── package.json
+├── src
+│   └── handlers
+│       ├── get-all-items.js
+│       ├── get-by-id.js
+│       └── put-item.js
+└── template.yml
+```
+
+And you want a package that looks like this on the inside:
+
+```bash
+.
+├── node_modules
+└── src
+```
+
+Then use this incantation, from the base folder.
+
+```bash
+docker run -it --rm -w /test -v $(pwd):/test \
+    -e NPM_PACKAGE_FILE=./package.json \
+    -e LAMBDA_SOURCE_DIR=src \
+    -e ARTIFACT_CODE_PREFIX=src \
+    3mcloud/lambda-packager:node-12.16
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # lambda-packager
 Package code for Python AWS Lambda functions using a docker container.
 
+## Python
 
 ### TL;DR for Python3.6
 
@@ -50,5 +51,35 @@ docker run -it --rm -e ARTIFACT_NAME=boston.zip -v $(pwd):$(pwd) -w $(pwd) 3mclo
 Do some crazy explicit stuff with the volume mapping:
 
 ```
-docker run -it --rm -v /Users/johndoe/my-lambda-source:/custom_build_dir -w /Users/johndoe/my-lambda-source 3mcloud/lambda-packager:python-3.6
+docker run -it --rm -v /Users/johndoe/my-lambda-source:/custom_build_dir -w /custom_build_dir lambda-packager:python-3.6
 ```
+
+## Node
+
+### TL;DR for Node
+
+Make sure:
+- your node code is in a folder called `src`, relative to the working directory
+- you have a `package.json` (and preferrably, also a `package-lock.json`) in your working directory
+
+```bash
+docker run -it --rm -v $(pwd):/workspace -w /workspace 3mcloud/lambda-packager:node-12.16
+```
+
+And **boom**, `deployment.zip` should be in your repository root.
+
+### Container variables for node
+
+You can change the default behavior of this packager by using the environment variables of the container
+
+| Variable Name | Default | Required | Description |
+|-------------- | ------- | ---------| ----------- |
+| `ARTIFACT_NAME` | `deployment.zip` | no | name of your artifact or zip file that you want to output |
+| `CONTAINER_BUILD_DIRECTORY` | `/build` | no | build output directory __inside__ your container |
+| `CI_WORKSPACE` | Docker working dir | no | workspace directory __inside__ your container |
+| `LAMBDA_CODE_DIR` | `src` | no | code directory of your lambda function |
+
+### Examples
+
+See the _Examples_ for Python, except where you see `3mcloud/lambda-packager:python-3.6` replace that 
+with `3mcloud/lambda-packager:node-12.16`

--- a/node/entrypoint.sh
+++ b/node/entrypoint.sh
@@ -5,7 +5,7 @@
 REPO_ROOT=$(pwd)
 CODE=${LAMBDA_CODE_DIR:-"src"}
 # Provides the ability for the src folder to still be nested.
-# For copmatibility reasons this is left to blank, but if 
+# For compatibility reasons this is left to blank, but if 
 # you wanted the "src" directory to be retained you would
 # set this to "src"
 ARTIFACT_PREFIX=${ARTIFACT_CODE_PREFIX:-""}

--- a/node/entrypoint.sh
+++ b/node/entrypoint.sh
@@ -1,27 +1,38 @@
 #!/bin/sh
 
 # Naming things
+# Assuming this is going to be the repository root
+REPO_ROOT=$(pwd)
 CODE=${LAMBDA_CODE_DIR:-"src"}
+# Provides the ability for the src folder to still be nested.
+# For copmatibility reasons this is left to blank, but if 
+# you wanted the "src" directory to be retained you would
+# set this to "src"
+ARTIFACT_PREFIX=${ARTIFACT_CODE_PREFIX:-""}
 ARTIFACT=${ARTIFACT_NAME:-"deployment.zip"}
 BUILD_DIR=${CONTAINER_BUILD_DIRECTORY:-"/build"}
 WORKSPACE=${CI_WORKSPACE:-$(pwd)}
-# These really aren't overridable for an npm install, so not 
-# giving the user a chance to modify it.
-PKG_FILE="package.json"
-PKG_LOCK="package-lock.json"
+
+# Allows package files in a different location to be copied to
+# the build folder 
+PKG_FILE=${NPM_PACKAGE_FILE:-${WORKSPACE}/${CODE}/"package.json"}
+PKG_LOCK=${NPM_PACKAGE_LOCK:-${WORKSPACE}/${CODE}/"package-lock.json"}
 
 ## Actually doing things
-mkdir -p ${BUILD_DIR}/${CODE}
-cp -R ${WORKSPACE}/${CODE}/. ${BUILD_DIR}/${CODE}
-cp ${WORKSPACE}/${PKG_FILE} ${BUILD_DIR}
-cp ${WORKSPACE}/${PKG_LOCK} ${BUILD_DIR}
+mkdir -p ${BUILD_DIR}/${ARTIFACT_PREFIX}
+
+cp -R ${WORKSPACE}/${CODE}/. ${BUILD_DIR}/${ARTIFACT_PREFIX}
+
+cp ${PKG_FILE} ${BUILD_DIR}
+cp ${PKG_LOCK} ${BUILD_DIR}
 
 cd ${BUILD_DIR}
 
-if [[ -f "${PKG_FILE}" ]]; then
+if [[ -f "$(basename ${PKG_FILE})" ]]; then
     npm install --production
 else
     echo "No requirements found. Skipping install"
 fi
 
-zip -r9 ${WORKSPACE}/${ARTIFACT} . -x ${PKG_FILE} -x ${PKG_LOCK}
+# This matches the documentation
+zip -r9 ${REPO_ROOT}/${ARTIFACT} . -x $(basename ${PKG_FILE}) -x $(basename ${PKG_LOCK})

--- a/node/entrypoint.sh
+++ b/node/entrypoint.sh
@@ -5,16 +5,19 @@ CODE=${LAMBDA_CODE_DIR:-"src"}
 ARTIFACT=${ARTIFACT_NAME:-"deployment.zip"}
 BUILD_DIR=${CONTAINER_BUILD_DIRECTORY:-"/build"}
 WORKSPACE=${CI_WORKSPACE:-$(pwd)}
+PKG_FILE=${NPM_PACKAGE_FILE:-"package.json"}
+PKG_LOCK=${NPM_PACKAGE_LOCK:-"package-lock.json"}
 
 ## Actually doing things
-mkdir -p ${BUILD_DIR}
-cp -R ${WORKSPACE}/${CODE}/. ${BUILD_DIR}
+mkdir -p ${BUILD_DIR}/${CODE}
+cp -R ${WORKSPACE}/${CODE}/. ${BUILD_DIR}/${CODE}
+cp ${WORKSPACE}/${PKG_FILE} ${BUILD_DIR}
+cp ${WORKSPACE}/${PKG_LOCK} ${BUILD_DIR}
 cd ${BUILD_DIR}
-if [ -e "package.json" ]; then
+if [[ -f "${PKG_FILE}" ]]; then
     npm install --production
 else
     echo "No requirements found. Skipping install"
 fi
-chmod -R 755 .
-zip -r9 ${WORKSPACE}/${ARTIFACT} . -x ${REQUIREMENTS_FILE} -x "${ARTIFACT}"
 
+zip -r9 ${WORKSPACE}/${ARTIFACT} . -x "${PKG_FILE}" -x "${PKG_LOCK}"

--- a/node/entrypoint.sh
+++ b/node/entrypoint.sh
@@ -5,19 +5,23 @@ CODE=${LAMBDA_CODE_DIR:-"src"}
 ARTIFACT=${ARTIFACT_NAME:-"deployment.zip"}
 BUILD_DIR=${CONTAINER_BUILD_DIRECTORY:-"/build"}
 WORKSPACE=${CI_WORKSPACE:-$(pwd)}
-PKG_FILE=${NPM_PACKAGE_FILE:-"package.json"}
-PKG_LOCK=${NPM_PACKAGE_LOCK:-"package-lock.json"}
+# These really aren't overridable for an npm install, so not 
+# giving the user a chance to modify it.
+PKG_FILE="package.json"
+PKG_LOCK="package-lock.json"
 
 ## Actually doing things
 mkdir -p ${BUILD_DIR}/${CODE}
 cp -R ${WORKSPACE}/${CODE}/. ${BUILD_DIR}/${CODE}
 cp ${WORKSPACE}/${PKG_FILE} ${BUILD_DIR}
 cp ${WORKSPACE}/${PKG_LOCK} ${BUILD_DIR}
+
 cd ${BUILD_DIR}
+
 if [[ -f "${PKG_FILE}" ]]; then
     npm install --production
 else
     echo "No requirements found. Skipping install"
 fi
 
-zip -r9 ${WORKSPACE}/${ARTIFACT} . -x "${PKG_FILE}" -x "${PKG_LOCK}"
+zip -r9 ${WORKSPACE}/${ARTIFACT} . -x ${PKG_FILE} -x ${PKG_LOCK}


### PR DESCRIPTION
Added README documentation for the node version of the container.

Update the entrypoint script, which in the case of the package files not being in the src directory was not installing the node_modules because it wasn't copying the package.json or package-lock.json to the build output directory before cd'ing to the build output directory to run `npm install`. 

Now the output zip file contains the code directory as well as the newly-installed node_modules directory and backwards compatibility has been retained. New environment variables are documented in the README along with an example.

Removed the chmod 755, as making all files executable was an unnecessary step here.

Updated the excludes for the `zip` command to leave the package.json and package-lock.json file out of the packaged file.